### PR TITLE
ci: publish db updates on dispatch instead of the weekly poll

### DIFF
--- a/.github/workflows/update-db.yml
+++ b/.github/workflows/update-db.yml
@@ -1,9 +1,16 @@
 name: Update Meta DB
 
 on:
-  # Weekly, shortly after lol-meta-classes' Sunday sync
+  # Pushed by LeagueToolkit/lol-meta-classes as soon as db/meta.db.json moves,
+  # so a new patch reaches the site in minutes rather than waiting for the cron.
+  repository_dispatch:
+    types: [meta-db-updated]
+
+  # Fallback for a missed or unauthenticated dispatch (expired token, failed
+  # upstream run). Weekly, shortly after lol-meta-classes' Sunday sync.
   schedule:
     - cron: '0 6 * * 0'
+
   workflow_dispatch:
 
 jobs:
@@ -11,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # For the explicit deploy trigger below.
+      actions: write
 
     steps:
       - uses: actions/checkout@v4
@@ -25,10 +34,12 @@ jobs:
         run: bun scripts/update-db.ts
 
       - name: Commit and push if changed
+        id: commit
         run: |
           set -e
           if git diff --quiet -- db/meta.db.json; then
             echo "Database is already up to date."
+            echo "pushed=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -39,3 +50,14 @@ jobs:
           git add db/meta.db.json
           git commit -m "chore: update meta db to patch ${PATCH}"
           git push
+          echo "pushed=true" >> $GITHUB_OUTPUT
+
+      # The push above is made with GITHUB_TOKEN, and GitHub does not raise
+      # `push` events for those - so deploy.yml would never see this commit and
+      # the new patch would sit in the repo, unpublished, until an unrelated
+      # human push happened to carry it out. Trigger it by hand.
+      - name: Trigger deploy
+        if: steps.commit.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy.yml --ref main


### PR DESCRIPTION
Lands the receiving half of the push-based handoff from `LeagueToolkit/lol-meta-classes`, ahead of the API v1 branch so the two can be reviewed separately. This file is self-contained — it does not touch `api/`.

### What changes

- **`repository_dispatch: [meta-db-updated]`** — lol-meta-classes announces a new `db/meta.db.json` the moment it lands, so a new patch publishes in minutes. Until now the only way in was the Sunday cron, so a mid-week sync sat unpublished for up to six days. The cron stays as a fallback for a missed or unauthenticated dispatch.
- **Explicit `deploy.yml` trigger after the auto-commit.** That push is made with `GITHUB_TOKEN`, and GitHub deliberately does not raise `push` events for those — so `deploy.yml` could never see it. A fetched patch would have sat in the repo unpublished until some unrelated human push carried it out. Latent rather than observed: every `Update Meta DB` run to date happened to be a no-op, so the commit step never fired.

### Requires

The sending half in `lol-meta-classes` (`notify-wiki.yml`) plus its `WIKI_DISPATCH_TOKEN` secret. Until that lands this is inert — the cron and `workflow_dispatch` behave exactly as before.

### Testing

`workflow_dispatch` this workflow after merge; with no upstream change it should report "Database is already up to date" and skip the deploy trigger.